### PR TITLE
Add JSON loader

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -15,8 +15,13 @@ const config = {
         loaders: ['style', 'raw'],
         include: path.resolve(__dirname, '../'),
       },
+      {
+        test: /\.json?$/,
+        loaders: ['json'],
+        include: path.resolve(__dirname, '../'),
+      },
     ],
-  },
+  }
 };
 
 updateConfig(config);

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "react": "^0.14.7 || ^15.0.0"
   },
   "dependencies": {
-    "babel-runtime": "^6.11.6"
+    "babel-runtime": "^6.11.6",
+    "json-loader": "^0.5.4"
   },
   "main": "dist/index.js",
   "engines": {


### PR DESCRIPTION
so that react-attr-converter module won't throw an 'Unexpected token'
error loading the map.json file.
