### PR TITLE
Remove unnecessary import from react-button example

### DIFF
--- a/src/stories/index.js
+++ b/src/stories/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { storiesOf, action, linkTo } from '@kadira/storybook';
+import { storiesOf, linkTo } from '@kadira/storybook';
 import Button from '../index';
 
 storiesOf('Button', module)


### PR DESCRIPTION
`import { action } from '@kadira/storybook'` created an unused import.